### PR TITLE
Added videogame and genre models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+node_modules

--- a/api/src/models/Genre.js
+++ b/api/src/models/Genre.js
@@ -1,0 +1,11 @@
+const mongoose = require("mongoose");
+
+
+const genreSchema = new mongoose.Schema({
+    name: {
+        type: String,
+        required: true
+    }
+});
+
+module.exports = mongoose.model("Genre", genreSchema)

--- a/api/src/models/Videogame.js
+++ b/api/src/models/Videogame.js
@@ -1,0 +1,34 @@
+const mongoose = require("mongoose");
+
+const videogameSchema = new mongoose.Schema ({
+    name : {
+        type: String,
+        required: true,
+    },
+    description: {
+        type: String,
+        required: true,
+    },
+    plataforms: {
+        type: [String],
+        required: true,
+    }, 
+    image: {
+        type: String,
+        required: true,
+    },
+    releaseDate: {
+        type:Date,
+        required: true,
+    },
+    rating: {
+        type: Number,
+        required: true,
+    },
+    genres: [{
+        type: mongoose.Schema.Types.ObjectId,
+        ref:"Genre", // Referencia al modelo Genre para simular many-to-many
+    }]
+})
+
+module.exports = mongoose.model("Videogame", videogameSchema);


### PR DESCRIPTION
Added Videogame and Genre Models
I have added the following models based on the provided specifications:

Model 1: Videogame
This model represents a video game with the following fields:

ID: Automatically generated by MongoDB.
Name (required): The name of the video game.
Description (required): A description of the video game.
Platforms (required): An array of strings representing the platforms on which the game is available.
Image (required): A URL for the game's image.
Release Date (required): The release date of the video game.
Rating (required): A numeric value representing the game's rating.
Genres (optional): An array of ObjectId references to the Genre model, simulating a many-to-many relationship.
Model 2: Genre
This model represents a genre with the following fields:

ID: Automatically generated by MongoDB.
Name (required): The name of the genre.

These models use Mongoose and simulate a many-to-many relationship between Videogame and Genre by referencing the Genre model in the Videogame model.

Let me know if you have any feedback or suggestions!